### PR TITLE
Add embeddable Q&A chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ The frontend requires both API keys because:
 Host `qa-interface.html` on your site and embed it using:
 
 ```html
-<iframe src="qa-interface.html" width="250" height="400" style="border:0" title="IITM Q&A"></iframe>
+<iframe src="qa-interface.html" width="400" height="400" style="border:0" title="IITM Q&A"></iframe>
 ```
 
 See `index.html` for a live example and additional guidance.

--- a/README.md
+++ b/README.md
@@ -369,6 +369,16 @@ The frontend requires both API keys because:
 
 **Test the iframe integration**: Open `iframe-test.html` to see how it looks embedded.
 
+### 🤖 **Embeddable Q&A Chatbot**
+
+Host `qa-interface.html` on your site and embed it using:
+
+```html
+<iframe src="qa-interface.html" width="250" height="400" style="border:0" title="IITM Q&A"></iframe>
+```
+
+See `index.html` for a live example and additional guidance.
+
 ### 🛠️ **JavaScript API**
 
 You can also use the JavaScript client directly:

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chatbot Embed</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body class="p-3">
+  <div class="container">
+    <h1 class="h4 mb-3">IITM Q&A Chatbot</h1>
+    <p>Embed the chatbot on any page with this HTML snippet:</p>
+    <pre><code>&lt;iframe src="qa-interface.html" width="250" height="400" style="border:0" title="IITM Q&amp;A"&gt;&lt;/iframe&gt;</code></pre>
+    <p class="mb-2">Preview:</p>
+    <iframe src="qa-interface.html" width="250" height="400" style="border:0" title="IITM Q&amp;A" class="border"></iframe>
+  </div>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
   <div class="container">
     <h1 class="h4 mb-3">IITM Q&A Chatbot</h1>
     <p>Embed the chatbot on any page with this HTML snippet:</p>
-    <pre><code>&lt;iframe src="qa-interface.html" width="250" height="400" style="border:0" title="IITM Q&amp;A"&gt;&lt;/iframe&gt;</code></pre>
+    <pre><code>&lt;iframe src="qa-interface.html" width="400" height="400" style="border:0" title="IITM Q&amp;A"&gt;&lt;/iframe&gt;</code></pre>
     <p class="mb-2">Preview:</p>
-    <iframe src="qa-interface.html" width="250" height="400" style="border:0" title="IITM Q&amp;A" class="border"></iframe>
+    <iframe src="qa-interface.html" width="400" height="400" style="border:0" title="IITM Q&amp;A" class="border"></iframe>
   </div>
 </body>
 

--- a/qa-interface.html
+++ b/qa-interface.html
@@ -4,18 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>IITM Q&A</title>
+  <title>IITM BS Admissions</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 
-<body class="p-2">
-  <h6 class="text-center mb-2">IITM Q&A</h6>
-  <div id="chat-area" class="small"></div>
-  <div id="loading" class="text-center my-2 d-none">
+<body class="d-flex flex-column h-100 p-2 small">
+  <h6 class="text-center mb-2 flex-shrink-0">IITM BS Admissions</h6>
+  <div id="chat-area" class="flex-grow-1 overflow-auto mb-2"></div>
+  <div id="loading" class="text-center my-2 d-none flex-shrink-0">
     <div class="spinner-border spinner-border-sm text-primary"></div>
   </div>
-  <div class="input-group">
+  <div class="input-group flex-shrink-0">
     <input id="question-input" type="text" class="form-control" placeholder="Ask a question" onkeypress="handleKeyPress(event)">
     <button id="ask-button" class="btn btn-primary" onclick="askQuestion()">Ask</button>
   </div>
@@ -28,13 +28,13 @@
     } from 'https://cdn.jsdelivr.net/npm/asyncllm@2'
     const WORKER_URL = 'https://semantic-qa-worker.kprudhvi71.workers.dev/answer'
     const chatArea = document.getElementById('chat-area')
-    const docsSection = document.createElement('details')
-    docsSection.id = 'docs-section'
-    docsSection.className = 'mt-2'
-    docsSection.innerHTML = '<summary>Source documents</summary><ul id="documents-container" class="list-unstyled ms-3"></ul>'
-    chatArea.appendChild(docsSection)
     const answerContainer = document.createElement('div')
     chatArea.appendChild(answerContainer)
+    const docsSection = document.createElement('details')
+    docsSection.id = 'docs-section'
+    docsSection.className = 'mt-3 p-2 border rounded bg-light d-none'
+    docsSection.innerHTML = '<summary>Source documents</summary><ul id="documents-container" class="list-unstyled ms-3 mb-0"></ul>'
+    chatArea.appendChild(docsSection)
 
     function handleKeyPress(e) {
       if (e.key === 'Enter') askQuestion()
@@ -50,6 +50,7 @@
       answerContainer.textContent = ''
       document.getElementById('documents-container').textContent = ''
       docsSection.classList.add('d-none')
+      docsSection.removeAttribute('open')
       document.getElementById('ask-button').disabled = true
       try {
         const marked = new Marked()
@@ -75,7 +76,7 @@
             if (data.type === 'document') {
               docCount++
               docsSection.classList.remove('d-none')
-              document.getElementById('documents-container').insertAdjacentHTML('beforeend', `<li><a href="${data.link}" target="_blank">${data.link.split('/').pop()}</a></li>`)
+              document.getElementById('documents-container').insertAdjacentHTML('beforeend', `<li class="mb-1"><a href="${data.link}" target="_blank">${data.link.split('/').pop()}</a></li>`)
             } else if (data.type === 'chunk') {
               buffer += data.text
               answerContainer.innerHTML = marked.parse(buffer.replace(/<[^>]*>/g, ''))

--- a/qa-interface.html
+++ b/qa-interface.html
@@ -9,7 +9,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 
-<body class="d-flex flex-column h-100 p-2 small">
+<body class="d-flex flex-column vh-100 p-2 small">
   <h6 class="text-center mb-2 flex-shrink-0">IITM BS Admissions</h6>
   <div id="chat-area" class="flex-grow-1 overflow-auto mb-2"></div>
   <div id="loading" class="text-center my-2 d-none flex-shrink-0">
@@ -28,33 +28,72 @@
     } from 'https://cdn.jsdelivr.net/npm/asyncllm@2'
     const WORKER_URL = 'https://semantic-qa-worker.kprudhvi71.workers.dev/answer'
     const chatArea = document.getElementById('chat-area')
-    const answerContainer = document.createElement('div')
-    chatArea.appendChild(answerContainer)
-    const docsSection = document.createElement('details')
-    docsSection.id = 'docs-section'
-    docsSection.className = 'mt-3 p-2 border rounded bg-light d-none'
-    docsSection.innerHTML = '<summary>Source documents</summary><ul id="documents-container" class="list-unstyled ms-3 mb-0"></ul>'
-    chatArea.appendChild(docsSection)
+    const askButton = document.getElementById('ask-button')
+    const questionInput = document.getElementById('question-input')
+    const loading = document.getElementById('loading')
+    let entryId = 0
+    let autoScroll = true
+    chatArea.addEventListener('scroll', () => {
+      const atBottom = chatArea.scrollHeight - chatArea.scrollTop - chatArea.clientHeight < 10
+      autoScroll = atBottom
+    })
+
+    function maybeScroll() {
+      if (autoScroll) chatArea.scrollTop = chatArea.scrollHeight
+    }
 
     function handleKeyPress(e) {
       if (e.key === 'Enter') askQuestion()
     }
 
-    function showError(msg) {
-      answerContainer.innerHTML = `<div class="alert alert-danger">${msg}</div>`
+    function escapeHtml(t) {
+      const m = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }
+      return t.replace(/[&<>"']/g, c => m[c])
+    }
+
+    function createEntry(q) {
+      entryId += 1
+      chatArea.insertAdjacentHTML('beforeend', `
+        <div class="mb-2" id="entry-${entryId}">
+          <div class="fw-bold">You:</div>
+          <div class="ms-3 mb-1">${escapeHtml(q)}</div>
+          <div class="fw-bold">Bot:</div>
+          <div class="ms-3 mb-1" id="answer-${entryId}"></div>
+          <details class="mt-2 p-2 border rounded bg-light d-none" id="docs-${entryId}">
+            <summary>Source documents</summary>
+            <ul class="list-unstyled ms-3 mb-0"></ul>
+          </details>
+        </div>`)
+      maybeScroll()
+      const ans = document.getElementById(`answer-${entryId}`)
+      const docs = document.querySelector(`#docs-${entryId} ul`)
+      const details = document.getElementById(`docs-${entryId}`)
+      return {
+        ans,
+        docs,
+        details
+      }
     }
     async function askQuestion() {
-      const q = document.getElementById('question-input').value.trim()
+      const q = questionInput.value.trim()
       if (!q) return
-      document.getElementById('loading').classList.remove('d-none')
-      answerContainer.textContent = ''
-      document.getElementById('documents-container').textContent = ''
-      docsSection.classList.add('d-none')
-      docsSection.removeAttribute('open')
-      document.getElementById('ask-button').disabled = true
+      questionInput.value = ''
+      askButton.disabled = true
+      loading.classList.remove('d-none')
+      const {
+        ans,
+        docs,
+        details
+      } = createEntry(q)
       try {
         const marked = new Marked()
-        let buffer = ''
+        let buf = ''
         let docCount = 0
         for await (const {
             message
@@ -71,27 +110,27 @@
           })) {
           const delta = message?.choices?.[0]?.delta?.content
           if (!delta) continue
-          try {
-            const data = JSON.parse(delta)
-            if (data.type === 'document') {
-              docCount++
-              docsSection.classList.remove('d-none')
-              document.getElementById('documents-container').insertAdjacentHTML('beforeend', `<li class="mb-1"><a href="${data.link}" target="_blank">${data.link.split('/').pop()}</a></li>`)
-            } else if (data.type === 'chunk') {
-              buffer += data.text
-              answerContainer.innerHTML = marked.parse(buffer.replace(/<[^>]*>/g, ''))
-            }
-          } catch {}
+          const data = JSON.parse(delta)
+          if (data.type === 'document') {
+            docCount++
+            details.classList.remove('d-none')
+            docs.insertAdjacentHTML('beforeend', `<li class="mb-1"><a href="${data.link}" target="_blank">${data.link.split('/').pop()}</a></li>`)
+          } else if (data.type === 'chunk') {
+            buf += data.text
+            ans.innerHTML = marked.parse(buf.replace(/<[^>]*>/g, ''))
+          }
+          maybeScroll()
         }
-        if (!docCount) document.getElementById('documents-container').insertAdjacentHTML('beforeend', '<li class="text-warning">No documents found</li>')
+        if (!docCount) docs.insertAdjacentHTML('beforeend', '<li class="text-warning">No documents found</li>')
       } catch (err) {
-        showError(err.message)
+        ans.innerHTML = `<div class="alert alert-danger">${err.message}</div>`
       } finally {
-        document.getElementById('ask-button').disabled = false
-        document.getElementById('loading').classList.add('d-none')
+        askButton.disabled = false
+        loading.classList.add('d-none')
+        maybeScroll()
       }
     }
-    document.getElementById('question-input').focus()
+    questionInput.focus()
     window.askQuestion = askQuestion
     window.handleKeyPress = handleKeyPress
 

--- a/qa-interface.html
+++ b/qa-interface.html
@@ -12,9 +12,6 @@
 <body class="d-flex flex-column vh-100 p-2 small">
   <h6 class="text-center mb-2 flex-shrink-0">IITM BS Admissions</h6>
   <div id="chat-area" class="flex-grow-1 overflow-auto mb-2"></div>
-  <div id="loading" class="text-center my-2 d-none flex-shrink-0">
-    <div class="spinner-border spinner-border-sm text-primary"></div>
-  </div>
   <div class="input-group flex-shrink-0">
     <input id="question-input" type="text" class="form-control" placeholder="Ask a question" onkeypress="handleKeyPress(event)">
     <button id="ask-button" class="btn btn-primary" onclick="askQuestion()">Ask</button>
@@ -30,7 +27,6 @@
     const chatArea = document.getElementById('chat-area')
     const askButton = document.getElementById('ask-button')
     const questionInput = document.getElementById('question-input')
-    const loading = document.getElementById('loading')
     let entryId = 0
     let autoScroll = true
     chatArea.addEventListener('scroll', () => {
@@ -61,10 +57,8 @@
       entryId += 1
       chatArea.insertAdjacentHTML('beforeend', `
         <div class="mb-2" id="entry-${entryId}">
-          <div class="fw-bold">You:</div>
-          <div class="ms-3 mb-1">${escapeHtml(q)}</div>
-          <div class="fw-bold">Bot:</div>
-          <div class="ms-3 mb-1" id="answer-${entryId}"></div>
+          <div class="bg-light border rounded p-2 mb-1">${escapeHtml(q)}</div>
+          <div class="mb-1" id="answer-${entryId}"></div>
           <details class="mt-2 p-2 border rounded bg-light d-none" id="docs-${entryId}">
             <summary>Source documents</summary>
             <ul class="list-unstyled ms-3 mb-0"></ul>
@@ -85,7 +79,7 @@
       if (!q) return
       questionInput.value = ''
       askButton.disabled = true
-      loading.classList.remove('d-none')
+      askButton.innerHTML = '<span class="spinner-border spinner-border-sm"></span>'
       const {
         ans,
         docs,
@@ -126,7 +120,7 @@
         ans.innerHTML = `<div class="alert alert-danger">${err.message}</div>`
       } finally {
         askButton.disabled = false
-        loading.classList.add('d-none')
+        askButton.innerHTML = 'Ask'
         maybeScroll()
       }
     }

--- a/qa-interface.html
+++ b/qa-interface.html
@@ -1,219 +1,100 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>IIT Madras Q&A Assistant</title>
-    <link rel="icon" type="image/png" href="https://study.iitm.ac.in/ds/assets/img/logo.png">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IITM Q&A</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
 </head>
-<body class="bg-light">
-    <div class="container-fluid py-3">
-        <!-- Header -->
-        <div class="row mb-3">
-            <div class="col-12">
-                <h4 class="text-primary mb-0 text-center">
-                    <i class="bi bi-chat-dots"></i> IIT Madras Q&A Assistant
-                </h4>
-                <div class="text-muted text-center">
-                    <small>Ask questions about the academic program</small>
-                </div>
-            </div>
-        </div>
 
-        <!-- Question Input -->
-        <div class="row mb-3">
-            <div class="col-12">
-                <div class="card">
-                    <div class="card-body">
-                        <div class="input-group">
-                            <input type="text" id="questionInput" class="form-control"
-                                   placeholder="Ask a question (e.g., What are the admission requirements?)"
-                                   onkeypress="handleKeyPress(event)">
-                            <button class="btn btn-primary" onclick="askQuestion()" id="askBtn">
-                                <i class="bi bi-send"></i> Ask
-                            </button>
-                        </div>
-                        <div class="form-text">
-                            <strong>Examples:</strong> admission requirements, course fees, registration process
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+<body class="p-2">
+  <h6 class="text-center mb-2">IITM Q&A</h6>
+  <div id="chat-area" class="small"></div>
+  <div id="loading" class="text-center my-2 d-none">
+    <div class="spinner-border spinner-border-sm text-primary"></div>
+  </div>
+  <div class="input-group">
+    <input id="question-input" type="text" class="form-control" placeholder="Ask a question" onkeypress="handleKeyPress(event)">
+    <button id="ask-button" class="btn btn-primary" onclick="askQuestion()">Ask</button>
+  </div>
+  <script type="module">
+    import {
+      Marked
+    } from 'https://cdn.jsdelivr.net/npm/marked@13/+esm'
+    import {
+      asyncLLM
+    } from 'https://cdn.jsdelivr.net/npm/asyncllm@2'
+    const WORKER_URL = 'https://semantic-qa-worker.kprudhvi71.workers.dev/answer'
+    const chatArea = document.getElementById('chat-area')
+    const docsSection = document.createElement('details')
+    docsSection.id = 'docs-section'
+    docsSection.className = 'mt-2'
+    docsSection.innerHTML = '<summary>Source documents</summary><ul id="documents-container" class="list-unstyled ms-3"></ul>'
+    chatArea.appendChild(docsSection)
+    const answerContainer = document.createElement('div')
+    chatArea.appendChild(answerContainer)
 
-        <!-- Results Row -->
-        <div class="row">
-            <!-- AI Answer (Left) -->
-            <div class="col-lg-7 col-md-12 mb-3">
-                <div class="card h-100">
-                    <div class="card-header bg-success text-white">
-                        <i class="bi bi-robot"></i> AI Answer
-                    </div>
-                    <div class="card-body">
-                        <div id="answerContainer" class="text-muted">
-                            <i class="bi bi-chat-square-text fs-1 opacity-25"></i>
-                            <p class="mt-2">Ask a question to get started</p>
-                        </div>
-                        <div id="loadingAnswer" class="d-none">
-                            <div class="d-flex align-items-center">
-                                <div class="spinner-border spinner-border-sm text-primary me-2"></div>
-                                <span>Generating answer...</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+    function handleKeyPress(e) {
+      if (e.key === 'Enter') askQuestion()
+    }
 
-            <!-- Documents (Right) -->
-            <div class="col-lg-5 col-md-12">
-                <div class="card h-100">
-                    <div class="card-header bg-info text-white">
-                        <i class="bi bi-file-text"></i> Source Documents
-                    </div>
-                    <div class="card-body">
-                        <div id="documentsContainer" class="text-muted text-center">
-                            <i class="bi bi-files fs-1 opacity-25"></i>
-                            <p class="mt-2">Relevant documents will appear here</p>
-                        </div>
-                        <div id="loadingDocs" class="d-none">
-                            <div class="d-flex align-items-center">
-                                <div class="spinner-border spinner-border-sm text-info me-2"></div>
-                                <span>Finding documents...</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script type="module">
-        import { Marked } from "https://cdn.jsdelivr.net/npm/marked@13/+esm";
-        import { asyncLLM } from "https://cdn.jsdelivr.net/npm/asyncllm@2";
-
-        const WORKER_URL = 'https://semantic-qa-worker.kprudhvi71.workers.dev/answer';
-
-        function handleKeyPress(event) {
-            if (event.key === 'Enter') {
-                askQuestion();
+    function showError(msg) {
+      answerContainer.innerHTML = `<div class="alert alert-danger">${msg}</div>`
+    }
+    async function askQuestion() {
+      const q = document.getElementById('question-input').value.trim()
+      if (!q) return
+      document.getElementById('loading').classList.remove('d-none')
+      answerContainer.textContent = ''
+      document.getElementById('documents-container').textContent = ''
+      docsSection.classList.add('d-none')
+      document.getElementById('ask-button').disabled = true
+      try {
+        const marked = new Marked()
+        let buffer = ''
+        let docCount = 0
+        for await (const {
+            message
+          }
+          of asyncLLM(WORKER_URL, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              q,
+              ndocs: 5
+            })
+          })) {
+          const delta = message?.choices?.[0]?.delta?.content
+          if (!delta) continue
+          try {
+            const data = JSON.parse(delta)
+            if (data.type === 'document') {
+              docCount++
+              docsSection.classList.remove('d-none')
+              document.getElementById('documents-container').insertAdjacentHTML('beforeend', `<li><a href="${data.link}" target="_blank">${data.link.split('/').pop()}</a></li>`)
+            } else if (data.type === 'chunk') {
+              buffer += data.text
+              answerContainer.innerHTML = marked.parse(buffer.replace(/<[^>]*>/g, ''))
             }
+          } catch {}
         }
+        if (!docCount) document.getElementById('documents-container').insertAdjacentHTML('beforeend', '<li class="text-warning">No documents found</li>')
+      } catch (err) {
+        showError(err.message)
+      } finally {
+        document.getElementById('ask-button').disabled = false
+        document.getElementById('loading').classList.add('d-none')
+      }
+    }
+    document.getElementById('question-input').focus()
+    window.askQuestion = askQuestion
+    window.handleKeyPress = handleKeyPress
 
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
-        }
-        const marked = new Marked();
-        async function askQuestion() {
-            const question = document.getElementById('questionInput').value.trim();
-            if (!question) return;
-
-            // Reset UI
-            const answerContainer = document.getElementById('answerContainer');
-            const documentsContainer = document.getElementById('documentsContainer');
-            const askBtn = document.getElementById('askBtn');
-
-            // Show loading states
-            document.getElementById('loadingAnswer').classList.remove('d-none');
-            document.getElementById('loadingDocs').classList.remove('d-none');
-            answerContainer.innerHTML = '';
-            documentsContainer.innerHTML = '';
-            askBtn.disabled = true;
-            askBtn.innerHTML = '<div class="spinner-border spinner-border-sm me-1"></div>Asking...';
-
-            try {
-                let documentCount = 0;
-                let answerStarted = false;
-                let answerBuffer = '';
-
-                for await (const { content, message } of asyncLLM(WORKER_URL, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ q: question, ndocs: 5 })
-                })) {
-                    // Use the raw message delta content instead of accumulated content
-                    const deltaContent = message?.choices?.[0]?.delta?.content;
-
-                    if (deltaContent) {
-                        try {
-                            const data = JSON.parse(deltaContent);
-
-                            if (data.type === 'document') {
-                                documentCount++;
-                                addDocument(data, documentCount);
-
-                                if (documentCount === 1) {
-                                    document.getElementById('loadingDocs').classList.add('d-none');
-                                }
-                            } else if (data.type === 'chunk') {
-                                if (!answerStarted) {
-                                    document.getElementById('loadingAnswer').classList.add('d-none');
-                                    answerContainer.innerHTML = '<div id="answerText"></div>';
-                                    answerStarted = true;
-                                }
-                                answerBuffer += data.text;
-                                // Display as markdown
-                                const answerText = document.getElementById('answerText');
-                                answerText.innerHTML = marked.parse(answerBuffer.replace(/<[^>]*>?/g, ''));
-                            }
-                        } catch (e) {
-                            console.error('JSON parse error:', e, 'Delta content:', deltaContent);
-                        }
-                    }
-                }
-
-                if (documentCount === 0) {
-                    documentsContainer.innerHTML = '<p class="text-warning">No documents found</p>';
-                }
-
-            } catch (error) {
-                console.error('Error:', error);
-                answerContainer.innerHTML = `<div class="alert alert-danger">Error: ${error.message}</div>`;
-                documentsContainer.innerHTML = '<p class="text-danger">Failed to load documents</p>';
-            } finally {
-                // Reset button
-                askBtn.disabled = false;
-                askBtn.innerHTML = '<i class="bi bi-send"></i> Ask';
-                document.getElementById('loadingAnswer').classList.add('d-none');
-                document.getElementById('loadingDocs').classList.add('d-none');
-            }
-        }
-
-        function addDocument(doc, index) {
-            const container = document.getElementById('documentsContainer');
-            const relevance = Math.round(doc.relevance * 100);
-            const preview = doc.text.substring(0, 120) + '...';
-            const filename = doc.link.split('/').pop().replace('.md', '');
-
-            const docElement = document.createElement('div');
-            docElement.className = 'border rounded p-2 mb-2 bg-white';
-            docElement.innerHTML = `
-                <div class="d-flex justify-content-between align-items-start mb-1">
-                    <small class="badge bg-primary">#${index}</small>
-                    <small class="badge bg-success">${relevance}% match</small>
-                </div>
-                <h6 class="mb-1 text-truncate" title="${filename}">${filename}</h6>
-                <p class="small text-muted mb-2">${preview}</p>
-                <a href="${doc.link}" target="_blank" class="btn btn-sm btn-outline-primary">
-                    <i class="bi bi-arrow-up-right"></i> View Source
-                </a>
-            `;
-
-            container.appendChild(docElement);
-        }
-
-        // Make functions globally available for inline event handlers
-        window.handleKeyPress = handleKeyPress;
-        window.askQuestion = askQuestion;
-
-        // Auto-focus on input when page loads
-        document.addEventListener('DOMContentLoaded', function() {
-            document.getElementById('questionInput').focus();
-        });
-    </script>
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
## Summary
- simplify QA interface for embedding
- provide `index.html` with embed instructions
- document embed snippet in README

## Testing
- `uvx ruff format --line-length 100 .`
- `npx -y prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `python3 run_tests.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6889b6a0e7a4832c9a10209ef2a3ac69